### PR TITLE
Patch sprint week1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ app.toPy('your ObjectID')
 ```
 
 ## Step by step guide
-<img src="tutorial.gif" />
+<img src="toPy.gif" />
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,28 @@ app = p2q.toQlik(df)
 app.toPy('your ObjectID')
 ```
 
-### Step by step guide
+## Step by step guide
 <img src="tutorial.gif" />
 
-### Current limitations ###
+---
+
+### Current limitations
 
 PyToQlik is currently implemented for QlikSense Desktop versions. Cloud and Enterprise versions of Qlik are still in active development.
+
+---
+
+### Features in development
+
+#### Connectivity
+- Qlik Enterprise support
+- Qlik Cloud support
+
+#### Functionality
+- Data fetching based on dimensions and measures
+- More robust embedding objects and sheets
+- More robust script editing
+- Object creation and manipulation via Python
+- Auxiliary functions, app listing and object listing
+- Task creation and managing
+- ETL features in Python


### PR DESCRIPTION
toPy:
now works dinamically (no more reloading/reopening apps)
now works for dashboards with multiple objects by grabbing the object handle correctly
returns dataframes correctly when no measures/no dimensions are selected in an object
now returns dataframe dimensions as expected
now handles HyperCube sizes to limit it to a single Qlik data page (dimension * measure <= 10000)
improved verbose and error handling

new function: listApps()
lists all apps inside Qlik's folder. returns name, path and file size

openApp:
improved verbose data and error handling
now works correctly with sheetName

toQlik:
now works for any number of dataframes you want to input
composes a script for all datasets inside a single Qlik script
added configurable separator for dataframe to csv files

Other:
improvements in readability, minor changes to organize code


